### PR TITLE
Replaced Bugsnag with Crashlytics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@
 # Certificates and API Keys
 #
 ReaderClientCert.sig
-bugsnag.conf
+google-services.json
 *.jks
 cardcreator.conf
 

--- a/.travis-pre.sh
+++ b/.travis-pre.sh
@@ -55,11 +55,6 @@ info "installing certificate"
 cp -v .travis/credentials/SimplyE/Android/ReaderClientCert.sig \
   app/src/main/assets/ReaderClientCert.sig
 
-info "installing bugsnag configuration"
-
-cp -v .travis/credentials/SimplyE/Android/bugsnag.conf \
-  app/src/main/assets/bugsnag.conf
-
 info "installing cardcreator configuration"
 
 cp -v .travis/credentials/SimplyE/Android/cardcreator.conf \

--- a/.travis-pre.sh
+++ b/.travis-pre.sh
@@ -54,6 +54,11 @@ info "installing certificate"
 
 cp -v .travis/credentials/SimplyE/Android/ReaderClientCert.sig \
   app/src/main/assets/ReaderClientCert.sig
+  
+info "installing crashlytics configuration"
+
+cp -v .travis/credentials/SimplyE/Android/google-services.json \
+   app/google-services.json
 
 info "installing cardcreator configuration"
 

--- a/README.md
+++ b/README.md
@@ -21,9 +21,8 @@ you probably want the [main framework repository](https://github.com/NYPL-Simpli
 
 #### Build!
 
-The short version: Install an [Android SDK](#android-sdk), configure
-[credentials for Nexus](#credentials), add a [Bugsnag](#bugsnag)
-API token, add an [Adobe DRM certificate](#adobe-drm), add a
+The short version: Install an [Android SDK](#android-sdk), configure Crashlytics, configure
+[credentials for Nexus](#credentials), add an [Adobe DRM certificate](#adobe-drm), add a
 [keystore](#apk-signing) and run:
 
 ~~~
@@ -65,6 +64,11 @@ OpenJDK Runtime Environment (build 1.8.0_222-b05)
 OpenJDK 64-Bit Server VM (build 25.222-b05, mixed mode)
 ~~~
 
+#### Crashlytics
+
+SimplyE uses Crashlytics for crash reporting. Obtain `google-services.json` and 
+place it in the `app` directory.
+
 #### Credentials
 
 Our application currently needs packages that are only available from
@@ -83,18 +87,6 @@ Once you have your credentials, the following lines must be added to `$HOME/.gra
 # Do NOT use quotes around either value.
 org.librarysimplified.nexus.username=USERNAME
 org.librarysimplified.nexus.password=PASSWORD
-~~~
-
-#### Bugsnag Support
-
-The project currently builds a version of the
-SimplyE application that supports error reporting via
-[Bugsnag](https://www.bugsnag.com/). This requires that a configuration
-file be placed at `app/src/main/assets/bugsnag.conf`
-containing your Bugsnag API token:
-
-~~~
-bugsnag.api_token = 1234123412341234
 ~~~
 
 #### Adobe DRM

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -63,10 +63,6 @@ android {
   lintOptions {
     checkReleaseBuilds false
   }
-
-  dexOptions {
-    javaMaxHeapSize "4g"
-  }
 }
 
 dependencies {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -63,6 +63,10 @@ android {
   lintOptions {
     checkReleaseBuilds false
   }
+
+  dexOptions {
+    javaMaxHeapSize "4g"
+  }
 }
 
 dependencies {
@@ -73,6 +77,7 @@ dependencies {
   implementation libraries.simplifiedAnalyticsCirculation
   implementation libraries.simplifiedMain
   implementation libraries.simplifiedMigrationFrom3Master
+  implementation libraries.firebaseAnalytics
 
   annotationProcessor libraries.googleAutoValue
 }
@@ -99,10 +104,10 @@ Obtain it from the private NYPL credentials repository.
 """)
   }
 
-  if (!file("${project.rootDir}/app/src/main/assets/bugsnag.conf").exists()) {
+  if (!file("${project.rootDir}/app/google-services.json").exists()) {
     throw new IllegalStateException("""
-You are attempting to build with Bugsnag but have not added the required
-configuration file at ${project.rootDir}/app/src/main/assets/bugsnag.conf.
+You have not added the required google-services.json file at 
+${project.rootDir}/app/google-services.json that is needed for Crashlytics.
 
 Obtain it from the private NYPL credentials repository.
 """)

--- a/app/src/main/assets/logback.xml
+++ b/app/src/main/assets/logback.xml
@@ -4,10 +4,6 @@
   <property name="EXT_FILES_DIR" value="${EXT_DIR:-/sdcard}/Android/data/${PACKAGE_NAME}/files"/>
   <property name="EXT_CACHE_DIR" value="${EXT_DIR:-/sdcard}/Android/data/${PACKAGE_NAME}/cache"/>
 
-  <appender
-    name="BUGSNAG"
-    class="org.nypl.simplified.bugsnag.BugsnagLogbackAppender"/>
-
   <!-- Create a logcat appender -->
   <appender
     name="LOG_CAT"
@@ -52,7 +48,6 @@
   <root level="DEBUG">
     <appender-ref ref="LOG_CAT" />
     <appender-ref ref="ASYNC_FILE" />
-    <appender-ref ref="BUGSNAG" />
   </root>
 
 </configuration>

--- a/app/src/main/assets/software-licenses.html
+++ b/app/src/main/assets/software-licenses.html
@@ -39,38 +39,6 @@ Delaware corporation having a place of business at 345 Park Avenue, San Jose, CA
 95110-2704, and with pebqem pty ltd (the “Adobe Supplier”), a corporation having a
 place of business at 59 Backland Road, Atlanta, GA 30342. See the END USER LICENSE
 AGREEMENT to understand rights granted in the application for its use.</p>
-<h2 id="bugsnag">Bugsnag</h2>
-<p>Copyright (c) 2012 Bugsnag, <a href="https://bugsnag.com/">https://bugsnag.com/</a></p>
-<p>Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the &quot;Software&quot;),
-to deal in the Software without restriction, including without limitation
-the rights to use, copy, modify, merge, publish, distribute, sublicense,
-and/or sell copies of the Software, and to permit persons to whom the Software
-is furnished to do so, subject to the following conditions:</p>
-<p>The above copyright notice and this permission notice shall be included in
- all copies or substantial portions of the Software.</p>
-<p>THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.</p>
-<p>Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:</p>
-<p>The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.</p>
-<p>THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.</p>
 
 </body>
 </html>

--- a/app/version.properties
+++ b/app/version.properties
@@ -1,4 +1,4 @@
 #
-#Mon Jan 06 21:16:01 UTC 2020
+#Fri Feb 07 08:47:29 CST 2020
 versionName=5.0.0-beta001
-versionCode=4067
+versionCode=4072

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ buildscript {
     classpath "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.20.0"
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     classpath 'com.android.tools.build:gradle:3.5.0'
+    classpath 'com.google.gms:google-services:4.3.3'
   }
 }
 
@@ -47,6 +48,7 @@ ext {
 
   nyplFindawayVersion = "3.0.2-beta005"
   simplifiedVersion = "5.0.0-SNAPSHOT"
+  firebaseVersion = "17.2.2"
 }
 
 ext.libraries = [
@@ -58,6 +60,7 @@ ext.libraries = [
   simplifiedAnalyticsCirculation     : "org.librarysimplified:org.librarysimplified.analytics.circulation:${simplifiedVersion}",
   simplifiedMain                     : "org.librarysimplified:org.librarysimplified.main:${simplifiedVersion}",
   simplifiedMigrationFrom3Master     : "org.librarysimplified:org.librarysimplified.migration.from3master:${simplifiedVersion}",
+  firebaseAnalytics                  : "com.google.firebase:firebase-analytics:${firebaseVersion}",
 ]
 
 apply plugin: "io.codearte.nexus-staging"
@@ -115,6 +118,7 @@ Automatic-Module-Name: ${POM_AUTOMATIC_MODULE_NAME}
 
       apply plugin: "com.android.application"
       apply plugin: "kotlin-android"
+      apply plugin: 'com.google.gms.google-services'
 
       android {
         compileSdkVersion androidCompileSDKVersion
@@ -270,6 +274,7 @@ Automatic-Module-Name: ${POM_AUTOMATIC_MODULE_NAME}
   repositories {
     mavenLocal()
     mavenCentral()
+    google()
 
     maven {
       url "https://oss.sonatype.org/content/repositories/snapshots/"


### PR DESCRIPTION
What's this do?
This replaces Bugsnag with Crashlytics

Why are we doing this? (w/ JIRA link if applicable)
No Jira task for this feature.

How should this be tested? / Do these changes have associated tests?
Simply running the app and forcing a crash will show in Firebase Console

Dependencies for merging? Releasing to production?
One thing to note, I did have to add dexOptions { javaMaxHeapSize "4g" } to get the build.gradle to build after adding Firebase.

Has the application documentation been updated for these changes?
Yes, I've removed the mentions of Bugsnag from the Readme and project licenses.

Did someone actually run this code to verify it works?