### PR TITLE
Release v5.0.0

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -69,6 +69,13 @@
       android:exported="false"
       android:label="@string/appName" />
 
+    <activity
+        android:name="org.nypl.simplified.cardcreator.CardCreatorActivity"
+        android:contentDescription="@string/appName"
+        android:exported="false"
+        android:label="@string/appName" />
+
+
   </application>
 
 </manifest>

--- a/app/version.properties
+++ b/app/version.properties
@@ -1,4 +1,4 @@
 #
-#Fri Mar 20 14:35:17 UTC 2020
-versionName=5.0.0-beta001
-versionCode=4071
+#Mon Apr 13 11:50:20 CDT 2020
+versionName=5.0.0
+versionCode=4136

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ ext {
   }
 
   nyplFindawayVersion = "4.0.0"
-  simplifiedVersion = "5.0.2-SNAPSHOT"
+  simplifiedVersion = "5.0.2"
 }
 
 ext.libraries = [


### PR DESCRIPTION
**What's this do?**
Updates version of Core that includes the card creator.

**Why are we doing this? (w/ JIRA link if applicable)**
[SIMPLY-2312: SA: Card creator](https://jira.nypl.org/browse/SIMPLY-2312)

**How should this be tested? / Do these changes have associated tests?**
1. Launch the application and add NYPL to accounts from Settings
2. Attempt to create a library card

**Dependencies for merging? Releasing to production?**
This will fail until we can get 5.0.0 of core pushed to Maven

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
@MalcolmMcFly 