### PR TITLE
Set sensible jvmargs in gradle.properties.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,3 +15,5 @@ VERSION_NAME=5.0.0-SNAPSHOT
 
 android.useAndroidX=true
 android.enableJetifier=true
+
+org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=1g


### PR DESCRIPTION
This prevents the build from shutting down gradle daemons due to memory
pressure.

Has no effect if 'org.gradle.jvmargs' is already defined in your
global 'gradle.properties'.