### PR TITLE
Added some missing Crashlytics dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -75,6 +75,7 @@ dependencies {
   implementation libraries.simplifiedMigrationFrom3Master
   implementation libraries.instabug
   implementation libraries.firebaseAnalytics
+  implementation libraries.firebaseCrashlytics
 
   annotationProcessor libraries.googleAutoValue
 }

--- a/app/version.properties
+++ b/app/version.properties
@@ -1,4 +1,4 @@
 #
-#Wed Apr 22 14:22:38 CDT 2020
+#Fri Apr 24 08:28:30 CDT 2020
 versionName=5.0.0-beta001
-versionCode=4102
+versionCode=4105

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ buildscript {
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     classpath 'com.android.tools.build:gradle:3.6.3'
     classpath 'com.google.gms:google-services:4.3.3'
+    classpath 'com.google.firebase:firebase-crashlytics-gradle:2.0.0-beta04'
   }
 }
 
@@ -62,6 +63,7 @@ ext.libraries = [
   simplifiedMain                     : "org.librarysimplified:org.librarysimplified.main:${simplifiedVersion}",
   simplifiedMigrationFrom3Master     : "org.librarysimplified:org.librarysimplified.migration.from3master:${simplifiedVersion}",
   firebaseAnalytics                  : "com.google.firebase:firebase-analytics:${firebaseVersion}",
+  firebaseCrashlytics                : "com.google.firebase:firebase-crashlytics:17.0.0-beta04",
 ]
 
 apply plugin: "io.codearte.nexus-staging"
@@ -76,6 +78,9 @@ nexusStaging {
 allprojects {
   group = project.ext["GROUP"]
   version = project.ext["VERSION_NAME"]
+  repositories {
+    google()
+  }
 }
 
 subprojects { project ->
@@ -120,6 +125,7 @@ Automatic-Module-Name: ${POM_AUTOMATIC_MODULE_NAME}
       apply plugin: "com.android.application"
       apply plugin: "kotlin-android"
       apply plugin: 'com.google.gms.google-services'
+      apply plugin: 'com.google.firebase.crashlytics'
 
       android {
         compileSdkVersion androidCompileSDKVersion

--- a/build.gradle
+++ b/build.gradle
@@ -73,8 +73,8 @@ subprojects {
 }
 
 ext.libraries = [
-        firebaseAnalytics                  : "com.google.firebase:firebase-analytics:${firebaseVersion}",
-        firebaseCrashlytics                : "com.google.firebase:firebase-crashlytics:17.0.0-beta04",
+  firebaseAnalytics                  : "com.google.firebase:firebase-analytics:${firebaseVersion}",
+  firebaseCrashlytics                : "com.google.firebase:firebase-crashlytics:17.0.0-beta04",
   googleAutoValue                    : "com.google.auto.value:auto-value:1.5",
   instabug                           : "com.instabug.library:instabug:9.1.3",
   nyplDRMAdobeProvider               : "org.librarysimplified.drm.adobe:org.librarysimplified.drm.adobe.provider:1.1.27",


### PR DESCRIPTION
**What's this do?**
Crashlytics was not fully implemented in SimplyE. How do I know? Risa reported a couple of crashes that did not appear in Crashlytics.  
Docs: https://firebase.google.com/docs/crashlytics/get-started-new-sdk?platform=android&authuser=0


**Why are we doing this? (w/ JIRA link if applicable)**
n/a

**How should this be tested? / Do these changes have associated tests?**
Simply run the project and observe the logs.

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
This code builds, but the implementation is not complete. Logs show the following:
`org.nypl.simplified.simplye E/FirebaseInstanceId: binding to the service failed` and on top of that, none of the Crashlytics methods are accessible from the classes in `org.nypl.simplified.simplye`.
