### PR TITLE
Removed the multidex support library.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -54,7 +54,6 @@ android {
   }
 
   defaultConfig {
-    multiDexEnabled true
     versionName = version.get(0)
     versionCode = version.get(1)
     setProperty("archivesBaseName", "simplye-${versionName}-${versionCode}")

--- a/build.gradle
+++ b/build.gradle
@@ -199,7 +199,6 @@ Automatic-Module-Name: ${POM_AUTOMATIC_MODULE_NAME}
         buildToolsVersion androidBuildToolsVersion
 
         defaultConfig {
-          multiDexEnabled true
           minSdkVersion androidMinimumSDKVersion
           targetSdkVersion androidTargetSDKVersion
           testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
Multidex is on by default in API 21 and above.

> If your `minSdkVersion` is set to 21 or higher, multidex is enabled by
default and you do not need the multidex support library.

https://developer.android.com/studio/build/multidex#mdex-gradle