### PR TITLE
Explicitly build debug with x86 support and release with ARM support.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,21 +17,20 @@ def versionValue() {
 }
 
 android {
+  defaultConfig {
+    versionCode = versionValue()
+    versionName = version
+    setProperty("archivesBaseName", "simplye-${version}-${versionCode}")
+  }
+
   packagingOptions {
-    exclude "META-INF/LICENSE"
+    doNotStrip 'lib/**/*.so'
 
-    doNotStrip "*/armeabi-v7a/*.so"
-    doNotStrip '*/arm64-v8a/*.so'
-
-    exclude ('/lib/mips/**')
-    exclude ('/lib/mips64/**')
-    exclude ('/lib/x86_64/**')
-    exclude ('/lib/x86/**')
-
-    // The PDF library and Readium both provide this shared library. This will
-    // cause the build to fail because Gradle doesn"t know which one to pick.
-    pickFirst "lib/arm64-v8a/libc++_shared.so"
-    pickFirst "lib/armeabi-v7a/libc++_shared.so"
+    // Readium and the PDF reader both provide this shared library. This causes
+    // the build to fail with an error because Gradle doesn't know which to pick.
+    pickFirst 'lib/x86/libc++_shared.so'
+    pickFirst 'lib/arm64-v8a/libc++_shared.so'
+    pickFirst 'lib/armeabi-v7a/libc++_shared.so'
   }
 
   signingConfigs {
@@ -44,15 +43,17 @@ android {
   }
 
   buildTypes {
+    debug {
+      ndk {
+        abiFilters 'x86', 'arm64-v8a', 'armeabi-v7a'
+      }
+    }
     release {
+      ndk {
+        abiFilters 'arm64-v8a', 'armeabi-v7a'
+      }
       signingConfig signingConfigs.release
     }
-  }
-
-  defaultConfig {
-    versionCode = versionValue()
-    versionName = version
-    setProperty("archivesBaseName", "simplye-${version}-${versionCode}")
   }
 
   lintOptions {


### PR DESCRIPTION
**What's this do?**
This change results in a debug version of SimplyE that supports the x86 architecture allowing the app to run in the Android
Emulator.

A release build will result in an apk that packages only the
supported ARM architectures, as before.

**Why are we doing this? (w/ JIRA link if applicable)**
See this discussion for some info on why we might want to do this:
https://github.com/NYPL-Simplified/Simplified-Android-Core/pull/779#issuecomment-673555986

**How should this be tested? / Do these changes have associated tests?**
n/a

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
@twaddington ran the app.