### PR TITLE
Add implementation of new CrashlyticsServiceType.

### DIFF
--- a/app/src/main/assets/logback.xml
+++ b/app/src/main/assets/logback.xml
@@ -29,6 +29,8 @@
     <appender-ref ref="FILE" />
   </appender>
 
+  <appender name="CRASHLYTICS" class="org.nypl.simplified.crashlytics.api.CrashlyticsLoggingAppender" />
+
   <logger
     name="org.nypl.simplified.app.catalog.CatalogFeedBookCellView"
     level="INFO" />
@@ -48,6 +50,7 @@
   <root level="DEBUG">
     <appender-ref ref="LOG_CAT" />
     <appender-ref ref="ASYNC_FILE" />
+    <appender-ref ref="CRASHLYTICS" />
   </root>
 
 </configuration>

--- a/app/src/main/java/org/nypl/simplified/simplye/SimplyECrashlyticsServiceType.kt
+++ b/app/src/main/java/org/nypl/simplified/simplye/SimplyECrashlyticsServiceType.kt
@@ -1,0 +1,50 @@
+package org.nypl.simplified.simplye
+
+import com.google.firebase.crashlytics.FirebaseCrashlytics
+import org.nypl.simplified.crashlytics.api.CrashlyticsServiceType
+
+class SimplyECrashlyticsServiceType : CrashlyticsServiceType {
+  private val instance by lazy {
+    FirebaseCrashlytics.getInstance()
+  }
+
+  override fun log(message: String) {
+    this.instance.log(message)
+  }
+
+  override fun recordException(throwable: Throwable) {
+    this.instance.recordException(throwable)
+  }
+
+  override fun setCollectionEnabled(enabled: Boolean) {
+    this.instance.setCrashlyticsCollectionEnabled(enabled)
+  }
+
+  override fun setUserId(identifier: String) {
+    this.instance.setUserId(identifier)
+  }
+
+  override fun setCustomKey(key: String, value: Int) {
+    this.instance.setCustomKey(key, value)
+  }
+
+  override fun setCustomKey(key: String, value: Long) {
+    this.instance.setCustomKey(key, value)
+  }
+
+  override fun setCustomKey(key: String, value: Float) {
+    this.instance.setCustomKey(key, value)
+  }
+
+  override fun setCustomKey(key: String, value: Double) {
+    this.instance.setCustomKey(key, value)
+  }
+
+  override fun setCustomKey(key: String, value: String) {
+    this.instance.setCustomKey(key, value)
+  }
+
+  override fun setCustomKey(key: String, value: Boolean) {
+    this.instance.setCustomKey(key, value)
+  }
+}

--- a/app/src/main/resources/META-INF/services/org.nypl.simplified.crashlytics.api.CrashlyticsServiceType
+++ b/app/src/main/resources/META-INF/services/org.nypl.simplified.crashlytics.api.CrashlyticsServiceType
@@ -1,0 +1,1 @@
+org.nypl.simplified.simplye.SimplyECrashlyticsServiceType

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ buildscript {
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     classpath 'com.android.tools.build:gradle:3.6.3'
     classpath 'com.google.gms:google-services:4.3.3'
-    classpath 'com.google.firebase:firebase-crashlytics-gradle:2.0.0-beta04'
+    classpath 'com.google.firebase:firebase-crashlytics-gradle:2.2.0'
   }
 }
 
@@ -48,7 +48,7 @@ ext {
   }
 
   nyplFindawayVersion = "5.0.0"
-  simplifiedVersion = "6.0.0"
+  simplifiedVersion = "6.0.0-SNAPSHOT"
   firebaseVersion = "17.2.2"
 }
 
@@ -74,7 +74,7 @@ subprojects {
 
 ext.libraries = [
   firebaseAnalytics                  : "com.google.firebase:firebase-analytics:${firebaseVersion}",
-  firebaseCrashlytics                : "com.google.firebase:firebase-crashlytics:17.0.0-beta04",
+  firebaseCrashlytics                : "com.google.firebase:firebase-crashlytics:17.1.1",
   googleAutoValue                    : "com.google.auto.value:auto-value:1.5",
   nyplDRMAdobeProvider               : "org.librarysimplified.drm.adobe:org.librarysimplified.drm.adobe.provider:1.1.27",
   nyplDRMCore                        : "org.librarysimplified.drm:org.librarysimplified.drm.core:1.1.2",

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ ext {
   }
 
   nyplFindawayVersion = "5.0.0"
-  simplifiedVersion = "6.0.0-SNAPSHOT"
+  simplifiedVersion = "6.1.0-SNAPSHOT"
   firebaseVersion = "17.2.2"
 }
 


### PR DESCRIPTION
**What's this do?**
See https://github.com/NYPL-Simplified/Simplified-Android-Core/pull/778

**How should this be tested? / Do these changes have associated tests?**
n/a

**Dependencies for merging? Releasing to production?**
We'll need to version bump core to something like `6.1.0-SNAPSHOT` and publish a new version to central before merging this.

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
@twaddington did.