### PR TITLE
Update build script to generate version code from semantic version string.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,24 +1,6 @@
-def versionValue() {
-  def propsFile = file("version.properties")
-  def Properties props = new Properties()
-  def code
-  if (propsFile.canRead()) {
-    props.load(new FileInputStream(propsFile))
-    code = props["versionCode"].toInteger()
-  } else {
-    throw new FileNotFoundException("Could not read version.properties!")
-  }
-
-  props["versionCode"] = (code + 1).toString()
-  props.save(new FileOutputStream(propsFile), "")
-
-  logger.info("incrementing build version ${code} -> ${code + 1}")
-  return code
-}
-
 android {
   defaultConfig {
-    versionCode = versionValue()
+    versionCode = versionCode(version)
     versionName = version
     setProperty("archivesBaseName", "simplye-${version}-${versionCode}")
   }

--- a/app/version.properties
+++ b/app/version.properties
@@ -1,4 +1,0 @@
-#
-#Thu Sep 24 09:15:41 CDT 2020
-versionName=5.0.0-beta001
-versionCode=4162

--- a/build.gradle
+++ b/build.gradle
@@ -342,3 +342,18 @@ Automatic-Module-Name: ${POM_AUTOMATIC_MODULE_NAME}
   }
 }
 
+/**
+ * Translate a semantic version into a numeric version code.
+ */
+static Integer versionCode(String versionName) {
+  def (major, minor, patch) = versionName
+          .replaceAll('[-+].*', '') // strip all metadata from version
+          .tokenize('.')
+
+  major = major.toInteger()
+  minor = minor.toInteger()
+  patch = patch.toInteger()
+
+  // Return version code padded with leading zeros
+  return String.format('%02d%02d%02d', major, minor, patch).toInteger()
+}


### PR DESCRIPTION
For example, the version 5.0.1 would generate a code of 50001.
