### PR TITLE
Correct Feedbooks configuration service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ cardcreator.conf
 google-services.json
 overdrive.json
 ReaderClientCert.sig
+feedbooks.conf
 
 # backup files
 *~

--- a/.travis-pre.sh
+++ b/.travis-pre.sh
@@ -73,7 +73,7 @@ cp -v ".travis/credentials/APK Signing/nypl-keystore.jks" \
 info "installing feedbooks.conf"
 
 cp -v ".travis/credentials/Feedbooks/feedbooks.conf" \
-  app/src/main/resources/org/nypl/simplified/simplye/feedbooks.conf || exit 1
+  app/src/main/assets/feedbooks.conf || exit 1
 
 info "installing overdrive.conf"
 

--- a/build.gradle
+++ b/build.gradle
@@ -102,7 +102,7 @@ task preFlightChecks {
     "app/src/main/assets/cardcreator.conf",
     "app/src/main/assets/overdrive.json",
     "app/src/main/assets/ReaderClientCert.sig",
-    "app/src/main/resources/org/nypl/simplified/simplye/feedbooks.conf",
+    "app/src/main/assets/feedbooks.conf",
   ]
 
   def missingFiles = []


### PR DESCRIPTION
**What's this do?**
The feedbooks configuration service wasn't being given the configuration file from assets.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-2301

**How should this be tested? / Do these changes have associated tests?**
Check that DPLA audio books download and can be heard.

**Dependencies for merging? Releasing to production?**
https://github.com/NYPL-Simplified/Simplified-Android-Core/pull/817

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@io7m listened to books in the DPLA test collection