### PR TITLE
Added Slack integration to Fastlane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -37,6 +37,10 @@ platform :android do
          groups: "librarysimplified",
          release_notes: "#{release_notes}",
          firebase_cli_path: ENV["FIREBASE_CLI_PATH"])
+
+     message = "SimplyE version 5.0.10 now available for QA. Work in this release: #{release_notes}"
+     slack_url = "https://hooks.slack.com/services/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"
+     slack(message: message, slack_url: slack_url, success: true)
     end
 
      # This needs to be tested as the .aab files have dynamic naming


### PR DESCRIPTION
**What's this do?**
This now sends release notes to #simplified-releases in the LibrarySimplified Slack channel. To accomplish, this a new webhook was added to the LibrarySimplified Slack workspace. See `Fastfile` for script updates.

**Why are we doing this? (w/ JIRA link if applicable)**
n/a

**How should this be tested? / Do these changes have associated tests?**
Run fastlane script from project root.

**Dependencies for merging? Releasing to production?**
The only call out here is that the version name is hard-coded in the Slack message. I would be nice to add an environment variable that can pull that version in automatically. Still trying to figure that out, so for now it must be updated manually.  

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
@MalcolmMcFly 